### PR TITLE
Improve speed of `shannon` and `ginisimpson`

### DIFF
--- a/src/diversity.jl
+++ b/src/diversity.jl
@@ -11,8 +11,9 @@ See also [`shannon!`](@ref).
 """
 function shannon(v::Union{AbstractVector{T}, AbstractSparseMatrix{T}}) where T<:Real
     total = sum(v)
-    relab = map(x-> x/total, v)
-    return -sum([log(x^x) for x in relab])
+    logtotal = log(total)
+    # The iszero condition is necessary to prevent log(0)
+    return logtotal - sum(x -> iszero(x) ? x : x * log(x), v) / total
 end
 
 function shannon(abt::AbstractAbundanceTable)
@@ -49,8 +50,7 @@ See also [`ginisimpson!`](@ref).
 """
 function ginisimpson(v::Union{AbstractVector{T}, AbstractSparseMatrix{T}}) where T<:Real
     total = sum(v)
-    relab = map(x-> x/total, v)
-    return 1 - sum([x^2 for x in relab])
+    return 1 - sum(x -> x^2, v) / (total^2)
 end
 
 function ginisimpson(abt::AbstractAbundanceTable)


### PR DESCRIPTION
Hi. I noticed that some computations could be saved in the definition of `shannon` and `ginisimpson`.

I am not a user of this package, so I am not sure about the impact. However, some measurements:
```
julia> const x = rand(1000);

julia> @btime shannon(x)
  148.720 μs (2 allocations: 15.88 KiB)
6.730219402261953

julia> @btime new_shannon(x)
  11.158 μs (0 allocations: 0 bytes)
6.730219402261952

julia> @btime ginisimpson(x)
  4.278 μs (2 allocations: 15.88 KiB)
0.9986907680545117

julia> @btime new_ginisimpson(x)
  296.874 ns (0 allocations: 0 bytes)
0.9986907680545117
```
The speed difference should increase with the length of the input.

Be aware that the result of the new `shannon` is little bit off due to numerical accuracy.